### PR TITLE
fix: HP => サイト

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -19,7 +19,7 @@ const TermPage: VFC = () => (
     </Head>
     <Layout>
       <div className={aboutPageStyles.wrapper}>
-        <h2 className={aboutPageStyles.midashi}>このHPについて</h2>
+        <h2 className={aboutPageStyles.midashi}>このサイトについて</h2>
         <p className={aboutPageStyles.text}>
           <a
             href="https://twitter.com/sadnessOjisan"


### PR DESCRIPTION
細かいんですけどちょっと気になってたやつです

導線
<img width="297" alt="Screen Shot 2021-07-12 at 19 35 56" src="https://user-images.githubusercontent.com/1996642/125273960-6d8c6500-e348-11eb-91e7-1abb05e45936.png">

https://shop.ojisan.io/about のh2箇所
<img width="277" alt="Screen Shot 2021-07-12 at 19 35 51" src="https://user-images.githubusercontent.com/1996642/125273954-6bc2a180-e348-11eb-9a83-cbadb8e3b14f.png">

「サイト」に揃えたい